### PR TITLE
Feature/isa 294@make workflow ifat

### DIFF
--- a/workflow.config.type.ts
+++ b/workflow.config.type.ts
@@ -456,7 +456,9 @@ export interface WorkflowConfigType {
     },
     publicRoutes?: {
       get?: Record<string, {
-        body: Record<'__extends' | '__omit' | '__cumulative' | string, string | string[]>
+        filter_scope?: WorkflowViewModeFilterScope[],
+        /** Se não for informado trará o flow_data.data completo */
+        body?: Record<'__extends' | '__omit' | '__cumulative' | string, string | string[]>
       }>,
       post?: Record<string, {
         /** Escopo de alteração dentro do objeto flow_data.data */
@@ -465,6 +467,8 @@ export interface WorkflowConfigType {
         body?: Record<'__extends' | '__omit' | '__cumulative' | string, string | string[]>,
         /** É utilizado apenas quando a requisição inclui find */
         mode?: 'merge' | 'overwrite',
+        /** Se for true, desabilita a funcionalidade find */
+        only_creation?: boolean,
         schema?: Record<string, FlowEntitySubSchema | FlowEntitySchemaInfo>,
       }>,
     }

--- a/workflow.config.type.ts
+++ b/workflow.config.type.ts
@@ -456,14 +456,7 @@ export interface WorkflowConfigType {
     },
     publicRoutes?: {
       get?: Record<string, {
-        auth?: {
-          /**
-           * @simple-token: Token criptografado armazenado no FlowEntity
-           */
-          mode: "@simple-token",
-          entity_key: string,
-          props: { token: string }
-        },
+        auth?: AuthPublicRouteType,
         /**
          * Query Params disponíveis para pesquisa.
          * 
@@ -477,14 +470,7 @@ export interface WorkflowConfigType {
         body?: Record<'__extends' | '__omit' | '__cumulative' | string, string | string[]>
       }>,
       post?: Record<string, {
-        auth?: {
-          /**
-           * @simple-token: Token criptografado armazenado no FlowEntity
-           */
-          mode: "@simple-token",
-          entity_key: string,
-          props: { token: string }
-        },
+        auth?: AuthPublicRouteType,
         /** Escopo de alteração dentro do objeto flow_data.data */
         scope?: string,
         /** Se não for informado trará o flow_data.data completo */
@@ -507,6 +493,14 @@ export interface WorkflowConfigType {
     email: string,
     whatsapp: string
   }
+}
+export interface AuthPublicRouteType{
+  /**
+   * @simple-token: Token criptografado armazenado no FlowEntity
+   */
+  mode: "@simple-token",
+  entity_key: string,
+  props: { token: string }
 }
 export interface WorkflowSlaOutherField extends Omit<StepSlaType, 'stay'>{
   /** Caminho dentro do flowData.data para o campo de data que gerencia esse SLA */

--- a/workflow.config.type.ts
+++ b/workflow.config.type.ts
@@ -456,6 +456,14 @@ export interface WorkflowConfigType {
     },
     publicRoutes?: {
       get?: Record<string, {
+        /**
+         * Query Params disponíveis para pesquisa.
+         * 
+         * Record< [query-param] , [path-no-flow-data] >
+         * 
+         * Palavras reservadas: take, skip
+         */
+        available_query_params?: Record<string, string>,
         filter_scope?: WorkflowViewModeFilterScope[],
         /** Se não for informado trará o flow_data.data completo */
         body?: Record<'__extends' | '__omit' | '__cumulative' | string, string | string[]>

--- a/workflow.config.type.ts
+++ b/workflow.config.type.ts
@@ -456,6 +456,14 @@ export interface WorkflowConfigType {
     },
     publicRoutes?: {
       get?: Record<string, {
+        auth?: {
+          /**
+           * @simple-token: Token criptografado armazenado no FlowEntity
+           */
+          mode: "@simple-token",
+          entity_key: string,
+          props: { token: string }
+        },
         /**
          * Query Params disponíveis para pesquisa.
          * 
@@ -469,6 +477,14 @@ export interface WorkflowConfigType {
         body?: Record<'__extends' | '__omit' | '__cumulative' | string, string | string[]>
       }>,
       post?: Record<string, {
+        auth?: {
+          /**
+           * @simple-token: Token criptografado armazenado no FlowEntity
+           */
+          mode: "@simple-token",
+          entity_key: string,
+          props: { token: string }
+        },
         /** Escopo de alteração dentro do objeto flow_data.data */
         scope?: string,
         /** Se não for informado trará o flow_data.data completo */

--- a/workflow.config.type.ts
+++ b/workflow.config.type.ts
@@ -1,4 +1,4 @@
-import { FlowEntitySchemaInfo, IntegrationExcelColumnTypeType, PermissionType, StepActionConfirmType, StepItemAttrMaskType, StepSlaType } from "."
+import { FlowEntitySchemaInfo, FlowEntitySubSchema, IntegrationExcelColumnTypeType, PermissionType, StepActionConfirmType, StepItemAttrMaskType, StepSlaType } from "."
 import { AvailableIcons } from "./icon.type";
 
 export type AvailableServicesType = 'email' | 'whatsapp' | 'sms' | 'chatbot';
@@ -459,10 +459,13 @@ export interface WorkflowConfigType {
         body: Record<'__extends' | '__omit' | '__cumulative' | string, string | string[]>
       }>,
       post?: Record<string, {
+        /** Escopo de alteração dentro do objeto flow_data.data */
         scope?: string,
-        body: Record<'__extends' | '__omit' | '__cumulative' | string, string | string[]>,
-        mode: 'merge' | 'overwrite',
-        schema?: Record<string, FlowEntitySchemaInfo>,
+        /** Se não for informado trará o flow_data.data completo */
+        body?: Record<'__extends' | '__omit' | '__cumulative' | string, string | string[]>,
+        /** É utilizado apenas quando a requisição inclui find */
+        mode?: 'merge' | 'overwrite',
+        schema?: Record<string, FlowEntitySubSchema | FlowEntitySchemaInfo>,
       }>,
     }
   },

--- a/workflow.entities.type.ts
+++ b/workflow.entities.type.ts
@@ -8,7 +8,8 @@ export interface FlowEntitySubSchema{
   type: 'sub-schema',
   label: string,
   placeholder: string,
-  schema: Record<string, FlowEntitySubSchema | FlowEntitySchemaInfo>
+  schema: Record<string, FlowEntitySubSchema | FlowEntitySchemaInfo>,
+  required?: boolean
 }
 export interface FlowEntitySchemaInfo{
   type: FlowEntitySchemaTypes,


### PR DESCRIPTION
## Descrição
Adicionado regras de autenticação via token em publicRoutes no workflow.config.<br/>
Também foi adicionado a capacidade do schema do publicRoutes[post] de lidar com subschemas, e os campos body mode se tornaram opcional tendo valores default documentados na tipagem.<br/>
Foi adicionado também a propriedade only_creation no publicRoutes[post] para bloquear uma rota para apenas criação.<br/>
Adicionando prop required em FlowEntitySubSchema.


## Mudanças Propostas
- WorkflowConfigType.services.publicRoutes [workflow.config.type.ts]
- FlowEntitySubSchema [workflow.entities.type.ts]

## Testes Realizados
- Manual (insomnia)

## Checklist
- [x] Os testes foram executados e passaram com sucesso.
- [x] A documentação foi atualizada, se necessário.
- [x] O código segue as diretrizes de estilo e padrões do projeto.
- [x] Foram feitas revisões de código internas.
- [ ] O código foi testado em diferentes navegadores/dispositivos (se aplicável).
- [x] Todas as alterações foram adequadamente comentadas e explicadas.

