### PR TITLE
Financial folder permissions

### DIFF
--- a/permission.type.ts
+++ b/permission.type.ts
@@ -11,6 +11,7 @@ export enum PossiblePermissions {
   INTEGRATION_WHATSAPP = 'integration-whatsapp',
   REPORT               = 'report',
   MANAGE_REPORT        = 'manage-report',
+  FINANCIAL_CLOSINGS   = 'financial-closings',
   // descontinuado ===============
   APPROVAL             = 'aprovacao',
   FINANCIAL_APPROVAL   = 'aprovacao-financeiro',


### PR DESCRIPTION
Descrição
Controle de Permissão Pasta de Fechamento Financeiro

Problema Relacionado
Acesso e rota para os fechamentos financeiros estavam abertos, sem nenhum controle de permissões.

Mudanças Propostas
Criação de uma categoria chamada FINANCIAL_CLOSINGS no PossiblePermissions, para através dela fazer verificações de acesso aos fechamentos financeiros.