### PR TITLE
IVR-50 - E-commerce auto aprovação e required observavel

### DIFF
--- a/step.item.field.type.ts
+++ b/step.item.field.type.ts
@@ -49,6 +49,7 @@ export interface StepItemType{
   options?: ValueAndNameStringType[],
   defaultValue?: any;
   required?: boolean,
+  required_if?: string,
   rules?: {
     min?: number,
     max?: number,


### PR DESCRIPTION
Adicionado required_if para definir se a obrigatoriedade do campo será a partir de uma string-condition