### PR TITLE
Ajuste na tipagem das configurações de integração do chatbot

### DIFF
--- a/workflow.config.type.ts
+++ b/workflow.config.type.ts
@@ -1047,7 +1047,7 @@ export interface WorkflowConfigIntegrationsChatbot{
      * - received: Confirmação de recebimento
      * - viewed:  Confirmação de visualização
      */
-    on: 'message' | 'sent' | 'received' | 'viewed',
+    on: 'message' | 'sent' | 'received' | 'viewed' | 'error',
   } & Omit<FlowMessageFnCallTrigger, 'execute'>>
 }
 


### PR DESCRIPTION
## Descrição
Ajuste na tipagem das configurações de integração do chatbot. 
Repositórios: ISAC front, back e shared types.

## Observações
O observer é adicionado nas configurações do workflow da seguinte forma:
```
{
    "on": "error",
    "mode": "call-trigger",
    "execute": "after",
    "data": {
      "trigger_id": "trg-mark-as-error",
      "effects": [
        {
          "only": "success",
          "breakExec": true
        }
      ],
      "params": {
        "pon": "@[curr.pon]",
        "default_message": "Houve um erro ao enviar a mensagem no provedor"
      }
    }
  }
```