### PR TITLE
Adicionados campos de limite de respostas erradas

### DIFF
--- a/flow_message.type.ts
+++ b/flow_message.type.ts
@@ -26,6 +26,10 @@ interface FlowMessageBase{
   fns?: FlowMessageFn[]
   store?: { interaction_data?: Record<string, any>, contact_data?: Record<string, any> }
 }
+export interface FlowMessageIfError {
+  count: number,
+  default_response: string
+}
 export interface FlowMessageInfoType extends FlowMessageBase{
   /** info: Informação apenas envia uma mensagem sem esperar retorno */
   mode: 'info',
@@ -56,6 +60,7 @@ export interface FlowMessageAskType extends FlowMessageBase{
   /** ask: É uma pergunta que necessita da resposta do cliente */
   mode: 'ask',
   condition?: string,
+  if_error?: FlowMessageIfError,
   /** respostas possíveis do usuário */
   responses: FlowMessageResponse[]
 }


### PR DESCRIPTION
## Descrição
Adicionados campos de limite de respostas erradas.
Repositórios: isac front, back e sht

## Observações
Campo parametrizado com quantidade de tentativas e a resposta padrão que vai redirecionar o cliente caso ele erre a quantidade de vezes inserida. 
![image](https://github.com/user-attachments/assets/69d1443c-27d3-4459-9b5f-67a35cbe7d04)
