### PR TITLE
IVR-226 - Melhorias solicidatas no wf de solicitação de promotores

### DIFF
--- a/workflow.config.events.type.ts
+++ b/workflow.config.events.type.ts
@@ -77,7 +77,10 @@ export interface ReplicateFlowDataType{
   inner_data?: Record<string, any>[],
   /** Campo referência para replicação */
   ref: string,
-  /** { 'campo-replicado': 'destino-do-campo' } */
+  /** 
+   * { 'campo-replicado': 'destino-do-campo' }
+   * Utilize _parent na 'campo-replicado' para referenciar o flowData principal
+   * */
   replace: Record<string, string>
   effects?: ReplicateFlowDataEffectType[],
   /**


### PR DESCRIPTION
## Descrição
- apenas um setor por ficha, comercial com permissão do setor 1 não pode abrir registro para o setor 2.
- o id não pode ser igual
-  não é necessário gestor comercial
- os anexos da loja devem aparecer no formulário do fornecedor

## Repositorios
ISAC
ISAC-BACK
SHT

## Mudanças Propostas
- Adicionado descrição no replace