### PR TITLE
AR-166: Permitindo a claro subir sem valor médio

### DIFF
--- a/exceptions/arion/CalculatorMatrix.ts
+++ b/exceptions/arion/CalculatorMatrix.ts
@@ -223,7 +223,7 @@ export class CalculatorMatrix {
     const monthly_fee = monthlyFee;
     const installation_fee = installationFee;
 
-    if (!monthly_fee || !installation_fee) throw new Error('Existem circuitos sem mensalidade ou taxa de instalação');
+    if (operator !== 'claro' && (!monthly_fee || !installation_fee)) throw new Error('Existem circuitos sem mensalidade ou taxa de instalação');
 
     // Validação da célula F2 da planilha
     // [ ] COLOCAR UMA VALIDAÇÃO PARA ISSO NO FLOW DATA, PORQUE O GRUPO "PREÇO DE VENDA RECORRENTE" E "PREÇO DE VENDA EVENTUAL OU TAXA DE INSTALAÇÃO VALIDAM POR ESSE CAMPO"


### PR DESCRIPTION
## Descrição
Permitindo a claro subir sem valor médio.
Repositórios: ISAC front, back e sht

## Problema Relacionado
[AR-166](https://ivrim.atlassian.net/jira/software/projects/AR/boards/108?selectedIssue=AR-166)