### PR TITLE
Separação de view modes por projeto no wf de provedores

### DIFF
--- a/workflow.config.type.ts
+++ b/workflow.config.type.ts
@@ -454,6 +454,17 @@ export interface ViewModeOrderBy{
   /** Utilizado apenas quando ViewMode é do tipo kanban e deseja ter um tipo de ordenação diferente por coluna */
   available_steps?: string[]
 }
+export interface WorkflowViewModeBaseSubOptions {
+  autocomplete: {
+    name: string,
+    condition?: string,
+    toFill: {
+      slug: string,
+      title: string,
+    },
+    filter_scope: WorkflowViewModeFilterScope[],
+  }
+}
 export interface WorkflowViewModeBase {
   title: string,
   description?: string,
@@ -479,7 +490,8 @@ export interface WorkflowViewModeBase {
    * Escopo de visualização do usuário. \
    * Está funcionalidade delimita os dados que este usuário pode interagir
    */
-  filter_scope?: WorkflowViewModeFilterScope[]
+  filter_scope?: WorkflowViewModeFilterScope[],
+  sub_options?: WorkflowViewModeBaseSubOptions,
   /** Caso essa opção seja configurada, ele redefinirá o comportamento padrão de redirecionamento
    *  de steps. Ou seja, quando clicar em um flowData na tabela, em vez de abrir o step atual, ele abrirá
    *  para o definido abaixo, e o mesmo se aplica após o envio do submit, que ele sempre redirecionará o


### PR DESCRIPTION
## Descrição
Separação de view modes por projeto no wf de provedores.
Repositórios: ISAC front, back e sht