### PR TITLE
MUF26.03.0024: Compradores e gerentes apenas visualizarem suas fichas

### DIFF
--- a/step.type.ts
+++ b/step.type.ts
@@ -134,7 +134,10 @@ export interface StepTypeRules{
   owner?: ('@data_creator' | '@current_user' | '@flow_data:n' | string)[],
   /** Seguindo as mesmas regras de owner */
   can_change_owner?: ('@data_creator' | '@current_user' | '@flow_data:n' | string)[],
+  /** se true, apenas um usuário pode ser selecionado */
   sole_owner?: boolean,
+  /** se true, o usuario não pode ser alterado */
+  immutable_owner?: boolean,
   /** Configura permissões personalizadas de ações dentro desta etapa */
   actions?: Record<WorkflowConfigActionsType['id'], {
     group_permission?: ('@data_creator' | '@data_owner' | '@not-allowed' | string)[],


### PR DESCRIPTION
## Descrição
Task: [MUF26.03.0024](https://isac.ivrim.com.br/#/modulo/68ee9aba0a225845f9f1d355?suboption=_&openBy=_id&_id=69bafd27ccb2775d62a144ba)

## Repositorios
ISAC
ISAC-BACK
SHT

## Mudanças Propostas
- Adicionado regra immutable_owner para bloqueio de alteração de usuarios.
