### PR TITLE
COV-100 : Melhorias do wf de introdução de forncedores

### DIFF
--- a/step.item.view.type.ts
+++ b/step.item.view.type.ts
@@ -257,12 +257,17 @@ export interface StepViewMarkdownType extends StepViewBaseType{
   type: 'markdown',
   url: string
 }
+export interface AvailableColumnsBadgeOption {
+  value: string,
+  color: 'gray' | 'red' | 'yellow' | 'green' | 'blue' | 'purple' | 'pink' | 'indigo',
+}
 export interface AvailableColumnsApproverControlType {
   key: string,
   label: string,
   type: StepItemAttrTypeType,
   mask?: StepItemAttrMaskType,
-  required?: boolean
+  required?: boolean,
+  badge?: AvailableColumnsBadgeOption[]
 }
 export interface StepActionApproverControlType {
   label: string,
@@ -355,6 +360,10 @@ export interface IDataExceptionApproverControl{
    * Utilizado para salvar o main no flowData
    * */
     path?: string,
+    /** 
+   * Utilizado desabilitar a edição
+   * */
+    disabled?: string
   }
 }
 export interface StepViewExceptionType extends StepViewBaseType{


### PR DESCRIPTION
## Descrição
01. [ ] O email da seleção de data veio como undefined
02. [x] O histórico de aprovação está vindo com undefined no titulo
03. [x] Em todas as ocorrências do componente de aprovação deixar o label dos status como Status Comercial e Status Executivo
04. [x] Colocar um badge no status com a coloração respectiva (aprovado/reprovado azul/vermelho)
05. [x] Nos status do executivo ter os botões 'De Acordo' e 'Discordar' que adicionaram o status 'De acordo' e 'Ag. Revisão'
06. [x] No histórico deve ser possível identificar se foi algo gerado na etapa do Executivo ou dos Setores.
07. [x] Remover coluna tipo do componente de aprovação
08. [x] Indicador de setor principal aparecer em todas ocorrência do componente, porém com edição apenas nas etapas do executivo (trazer o primeiro setor como default selected).
09. [x] Colocar th Histórico, e adicionar quantidade de logs na frente do icone, e mudar a cor para text-gray-500

## Repositorios
ISAC
ISAC-BACK
SHT

## Mudanças Propostas
- Adicionado badges e disableb na edição de princial no componenete de aprovadores